### PR TITLE
Another name for docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - validate
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2
       - name: Prepare tag names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Prepare tag names
         id: prep
         run: |
-          DOCKER_IMAGE=poanetwork/nft-omnibridge-contracts
+          DOCKER_IMAGE=omni/nft-contracts
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             echo ::set-output name=tags::${DOCKER_IMAGE}:${GITHUB_REF#refs/tags/},${DOCKER_IMAGE}:latest
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - validate
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2
       - name: Prepare tag names

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Prepare tag names
         id: prep
         run: |
-          DOCKER_IMAGE=omni/nft-contracts
+          DOCKER_IMAGE=omnibridge/nft-contracts
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             echo ::set-output name=tags::${DOCKER_IMAGE}:${GITHUB_REF#refs/tags/},${DOCKER_IMAGE}:latest
           else


### PR DESCRIPTION
This PR is continuation of the activity to move omnibridge related items to the separate organization. It is suggested to move the docker images with contracts' deployment scripts to the `omnibridge` organization on the docker hub: https://hub.docker.com/orgs/omnibridge/repositories