### PR TITLE
Refactor of docker image to deploy and verify without flattened contracts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ flats
 contracts.sublime-project
 contracts.sublime-workspace
 build/
+package-lock.json

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 build
 coverage
+deploy/src/remix-helpers

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ deploy/*.env*
 !deploy/.env.example
 deploy/bridgeDeploymentResults.json
 coverage.json
+package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14 as contracts
 
-WORKDIR /contracts
+WORKDIR /workdir
 
 COPY package.json yarn.lock ./
 RUN yarn
@@ -11,14 +11,25 @@ RUN yarn compile
 
 FROM node:14
 
-WORKDIR /contracts
+WORKDIR /workdir
 
 COPY package.json yarn.lock ./
 RUN yarn install --prod
 
-COPY --from=contracts /contracts/build ./build
+# Allows remixd to be run within a docker container
+RUN sed -i s/127.0.0.1/0.0.0.0/g node_modules/@remix-project/remixd/websocket.js
+
+COPY truffle-config.js truffle-config.js
+# No need to have coverage module within the container
+RUN sed -i s/\'solidity-coverage\'\,\ // truffle-config.js
+
+COPY ./contracts ./contracts
+
+COPY --from=contracts /workdir/build ./build
 
 COPY deploy.sh deploy.sh
 COPY ./deploy ./deploy
 
-ENV PATH="/contracts/:${PATH}"
+EXPOSE 65520
+
+ENV PATH="/workdir:/workdir/node_modules/.bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 [![Join the chat at https://gitter.im/poanetwork/poa-bridge](https://badges.gitter.im/poanetwork/poa-bridge.svg)](https://gitter.im/poanetwork/poa-bridge?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://github.com/omni/omnibridge-nft/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/omni/omnibridge-nft/actions/workflows/main.yml)
 
-# Omnibridge NFT Smart Contracts
-These contracts provide the core functionality for the Omnibridge NFT AMB extension.
+NFT OmniBridge Contracts
+====
+
+These contracts provide the core functionality for the NFT Omnibridge AMB extension.
+
+More details about AMB (Arbitrary Message Bridge) extensions can be found [here](https://docs.tokenbridge.net/amb-bridge/about-amb-bridge). The AMB repository is [poanetwork/tokenbridge-contracts](https://github.com/poanetwork/tokenbridge-contracts).
 
 ## License
 

--- a/REMIX.md
+++ b/REMIX.md
@@ -1,0 +1,42 @@
+How to access the contracts in the Remix IDE
+====
+
+It is possible to use the docker container to modify, test and deploy the contracts in the Remix IDE.
+
+## Read-Only Access
+
+If it is not needed to modify the contracts, they can be opened in the Remix IDE without necessity to clone the repo:
+
+1. Pull the docker image 
+   ```
+   docker pull omnibridge/nft-contracts:latest
+   ```
+
+2. Run the container
+   ```
+   docker run -d --rm --name nft-ob-remixd -p 65520:65520 
+       omnibridge/nft-contracts:latest yarn remixd
+   ```
+
+3. Open a new workspace [through connectivity to localhost](https://remix-ide.readthedocs.io/en/latest/remixd.html) in the Remix IDE. It is important to use HTTPS to access the IDE: https://remix.ethereum.org/.
+
+## Keep the changes
+
+In case of the modification of the contracts it makes sense to mount the local directory with the git repo in the Remix IDE.
+
+1. Pull the docker image 
+   ```
+   docker pull omnibridge/nft-contracts:latest
+   ```
+2. Move to the directory with the contracts.
+   ```
+   cd omnibridge-nft
+   ```
+
+3. Run the container
+   ```
+   docker run -d --rm --name nft-ob-remixd -p 65520:65520
+       -v $(pwd):/workdir omnibridge/nft-contracts:latest yarn remixd
+   ```
+
+4. Open a new workspace [through connectivity to localhost](https://remix-ide.readthedocs.io/en/latest/remixd.html) in the Remix IDE. It is important to use HTTPS to access the IDE: https://remix.ethereum.org/.

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,21 +11,5 @@ if [ -f /.dockerenv ]; then
   exit 0
 fi
 
-which docker-compose > /dev/null
-if [ "$?" == "1" ]; then
-  echo "docker-compose is needed to use this type of deployment"
-  exit 1
-fi
-
-if [ ! -f ./deploy/.env ]; then
-  echo "The .env file not found in the 'deploy' directory"
-  exit 3
-fi
-
-docker-compose images nft-omnibridge-contracts >/dev/null 2>/dev/null
-if [ "$?" == "1" ]; then
-  echo "Docker image 'nft-omnibridge-contracts' not found"
-  exit 2
-fi
-
-docker-compose run nft-omnibridge-contracts deploy.sh "$@"
+echo "The deployment must start withing the docker container"
+exit 1

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -23,14 +23,6 @@ FOREIGN_AMB_BRIDGE=
 HOME_MEDIATOR_REQUEST_GAS_LIMIT=
 FOREIGN_MEDIATOR_REQUEST_GAS_LIMIT=
 
-# Supported explorers: Blockscout, etherscan
-HOME_EXPLORER_URL=https://blockscout.com/poa/sokol/api
-HOME_EXPLORER_API_KEY=
-
-# Supported explorers: Blockscout, etherscan
-FOREIGN_EXPLORER_URL=https://api-kovan.etherscan.io/api
-FOREIGN_EXPLORER_API_KEY=
-
 HOME_ERC721_TOKEN_IMAGE=0x
 HOME_ERC1155_TOKEN_IMAGE=0x
 HOME_FORWARDING_RULES_MANAGER=false

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,7 +23,7 @@ It is assumed that Docker is installed on the system.
 
 4. Run the docker container:
    ```
-   docker run -ti --rm --env-file nft-ob.env omnibridge/nft-contracts:2.0.0-rc4 deploy.sh
+   docker run -ti --rm --env-file nft-ob.env omnibridge/nft-contracts:latest deploy.sh
    ```
 
 ## Deployment with Yarn

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,33 +1,63 @@
-# How to Deploy POA Bridge Contracts
+How to deploy NFT OmniBridge AMB extension contracts
+====
 
-In order to deploy bridge contracts you must run `yarn` to install all dependencies. For more information, see the [project README](../README.md).
+There are two options to deploy NFT OB contracts: 
+  * with docker image, it could be useful for systems where there is no Node.JS environment configured
+  * with `yarn`, for the cases where customization in the contracts code is required
+
+If necessary, deploy and configure a multi-sig wallet contract to manage the bridge contracts after deployment. We have not audited any wallets for security, but have used [Gnosis Safe](https://gnosis-safe.io/) with success.
+
+## Deployment with Docker
+
+It is assumed that Docker is installed on the system.
+
+1. Pull the docker image:
+
+   ```
+   docker pull omnibridge/nft-contracts:latest
+   ```
+
+2. Create a `nft-ob.env` file with the NFT OB configuration parameters. See below for comments related to each parameter.
+
+3. Add funds to the deployment account in both the Home and Foreign networks.
+
+4. Run the docker container:
+   ```
+   docker run -ti --rm --env-file nft-ob.env omnibridge/nft-contracts:2.0.0-rc4 deploy.sh
+   ```
+
+## Deployment with Yarn
+
+Before deploying of the NFT OB contracts you must run `yarn` to install all dependencies.
 
 1. Compile the source contracts.
-```
-cd ..
-yarn compile
-```
+   ```
+   cd ..
+   yarn compile
+   ```
 
 2. Create a `.env` file.
-```
-cd deploy
-cp env.example .env
-```
+   ```
+   cd deploy
+   cp env.example .env
+   ```
 
-3. If necessary, deploy and configure a multi-sig wallet contract to manage the bridge contracts after deployment. We have not audited any wallets for security, but have used https://github.com/gnosis/MultiSigWallet/ with success.
+3. Adjust the parameters in the `.env` file. See below for comments related to each parameter.
 
-4. Adjust the parameters in the `.env` file depending on the desired bridge mode. See below for comments related to each parameter.
+4. Add funds to the deployment account in both the Home and Foreign networks.
 
-5. Add funds to the deployment accounts in both the Home and Foreign networks.
+5. Run `yarn deploy`.
 
-6. Run `yarn deploy`.
+## Contracts verification
 
-## `OMNIBRIDGE_NFT` Bridge Mode Configuration Example.
+The contracts are not automatically verified during deployment. In order to publish the contracts' code in Etherscan/Blockscout, follow [these instructions](VERIFICATION.md)
 
-This example of an `.env` file for the `OMNIBRIDGE_NFT` bridge mode includes comments describing each parameter.
+## NFT OB configuration parameters clarification
+
+This example of an `.env` file for the NFT OmniBridge includes comments describing each parameter.
 
 ```bash
-# The type of bridge. Defines set of contracts to be deployed.
+# Don't change this parameter
 BRIDGE_MODE=OMNIBRIDGE_NFT
 
 # The private key hex value of the account responsible for contracts
@@ -102,13 +132,4 @@ HOME_TOKEN_NAME_SUFFIX=""
 # suffix used for token names for tokens bridged from Home to Foreign
 # usually you might want it to start with a space character
 FOREIGN_TOKEN_NAME_SUFFIX=""
-
-# The api url of an explorer to verify all the deployed contracts in Home network. Supported explorers: Blockscout, etherscan
-#HOME_EXPLORER_URL=https://blockscout.com/poa/core/api
-# The api key of the explorer api, if required, used to verify all the deployed contracts in Home network.
-#HOME_EXPLORER_API_KEY=
-# The api url of an explorer to verify all the deployed contracts in Foreign network. Supported explorers: Blockscout, etherscan
-#FOREIGN_EXPLORER_URL=https://api.etherscan.io/api
-# The api key of the explorer api, if required, used to verify all the deployed contracts in Foreign network.
-#FOREIGN_EXPLORER_API_KEY=
 ```

--- a/deploy/VERIFICATION.md
+++ b/deploy/VERIFICATION.md
@@ -1,9 +1,26 @@
-## Process
+NFT OB contracts verification
+====
+
+The instructions below are to guide through the NFT OmniBridge contracts verification process to have the contracts sources published in Etherscan/Blockscout.
+
+## Intro
 
 Due to usage of `pragma abicoder v2;` in the contracts source code,
 it is not possible to verify contracts through flattened source files.
 
 Instead, two different approaches can be used for Etherscan and Blockscout explorers.
+
+The scripts below relay on the following environment variables (can be defined through the `.env` file):
+  * `FOREIGN_RPC_URL` or `HOME_RPC_URL` used to get the chain id and the contract's constructor parameters
+  * `FOREIGN_EXPLORER_API_KEY` or `HOME_EXPLORER_API_KEY` provides an api key of the explorer api (Etherscan or Bscscan)
+
+### A note for running in the docker container
+
+It is possible to run the verification process if the docker image was used for deployment. It can be done by running a shell session within the container. For example,
+```
+docker run -ti --rm -e FOREIGN_RPC_URL=... -e FOREIGN_EXPLORER_API_KEY=... \
+    omnibridge/nft-contracts:2.0.0-rc4 bash
+```
 
 ## Verification in Etherscan/Bscscan
 
@@ -46,9 +63,9 @@ VERIFY_HOME=true deploy/verifyEtherscan.sh HomeNFTOmnibridge@0xFF9c66898B706cd56
 In order to verify multi-file contract in Blockscout, it must support Sourcify integration (present in the xDAI instance).
 
 The list of actions is the following:
-1) Upload contracts sources and metadata to IPFS.
-2) Wait until Sourcify monitor will handle uploaded files and will automatically verify deployed contracts.
-3) Import sources to blockscout from Sourcify database.
+1. Upload contracts sources and metadata to IPFS.
+2. Wait until Sourcify monitor will handle uploaded files and will automatically verify deployed contracts.
+3. Import sources to blockscout from Sourcify database.
 
 ### Upload to IPFS
 

--- a/deploy/VERIFICATION.md
+++ b/deploy/VERIFICATION.md
@@ -19,7 +19,7 @@ The scripts below relay on the following environment variables (can be defined t
 It is possible to run the verification process if the docker image was used for deployment. It can be done by running a shell session within the container. For example,
 ```
 docker run -ti --rm -e FOREIGN_RPC_URL=... -e FOREIGN_EXPLORER_API_KEY=... \
-    omnibridge/nft-contracts:2.0.0-rc4 bash
+    omnibridge/nft-contracts:latest bash
 ```
 
 ## Verification in Etherscan/Bscscan

--- a/deploy/src/remix-helpers/deploy-foreign-mediator.js
+++ b/deploy/src/remix-helpers/deploy-foreign-mediator.js
@@ -1,0 +1,28 @@
+// This script is to be used from Remix IDE to deploy NFT OB AMB extension
+
+(async () => {
+  try {
+    const suffix = ' from xDai'
+    const compiled_json = 'contracts/upgradeable_contracts/omnibridge_nft/artifacts/ForeignNFTOmnibridge.json'
+    
+    console.log('deploy...')
+
+    const metadata = JSON.parse(await remix.call('fileManager', 
+                                                 'getFile', 
+                                                 compiled_json))
+    const accounts = await web3.eth.getAccounts()
+
+    let contract = new web3.eth.Contract(metadata.abi)
+
+    contract = await contract.deploy({
+      data: metadata.data.bytecode.object,
+      arguments: [suffix]
+    }).send({
+      from: accounts[0]
+    })
+
+    console.log(contract.options.address)
+  } catch (e) {
+    console.log(e.message)
+  }
+})()

--- a/deploy/src/remix-helpers/deploy-home-mediator.js
+++ b/deploy/src/remix-helpers/deploy-home-mediator.js
@@ -1,0 +1,28 @@
+// This script is to be used from Remix IDE to deploy NFT OB AMB extension
+
+(async () => {
+  try {
+    const suffix = ' from Mainnet'
+    const compiled_json = 'contracts/upgradeable_contracts/omnibridge_nft/artifacts/HomeNFTOmnibridge.json'
+    
+    console.log('deploy...')
+
+    const metadata = JSON.parse(await remix.call('fileManager', 
+                                                 'getFile', 
+                                                 compiled_json))
+    const accounts = await web3.eth.getAccounts()
+
+    let contract = new web3.eth.Contract(metadata.abi)
+
+    contract = await contract.deploy({
+      data: metadata.data.bytecode.object,
+      arguments: [suffix]
+    }).send({
+      from: accounts[0]
+    })
+
+    console.log(contract.options.address)
+  } catch (e) {
+    console.log(e.message)
+  }
+})()

--- a/deploy/verifyEtherscan.sh
+++ b/deploy/verifyEtherscan.sh
@@ -4,7 +4,9 @@ set -e
 
 cd $(dirname $0)
 
-source .env
+if [ -f .env ]; then
+  source .env
+fi
 
 if [ "$VERIFY_HOME" = "true" ]; then
   VERIFICATION_RPC_URL="$HOME_RPC_URL"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,5 @@
 version: "3.3"
 services:
-  nft-omnibridge-contracts:
-    build: .
-    command: "true"
-    env_file: ./deploy/.env
   dev:
     build:
       context: .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnibridge-nft",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0-rc4",
   "description": "Omnibridge NFT AMB extension",
   "main": "index.js",
   "scripts": {
@@ -13,10 +13,13 @@
     "lint:sol": "solhint --max-warnings 0 \"contracts/**/*.sol\"",
     "lint:sol:prettier:fix": "prettier --write \"contracts/**/*.sol\"",
     "deploy": "node deploy/deploy.js",
+    "remixd": "remixd -s /workdir --remix-ide https://remix.ethereum.org",
     "e2e-tests:local": "./e2e-tests/run-tests.sh local",
     "e2e-tests:public": "./e2e-tests/run-tests.sh"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "3.4.1-solc-0.7-2",
+    "@remix-project/remixd": "0.3.5",
     "axios": "^0.21.0",
     "bignumber.js": "^9.0.1",
     "dotenv": "^8.2.0",
@@ -25,10 +28,11 @@
     "promise-retry": "^2.0.1",
     "querystring": "^0.2.0",
     "shelljs": "^0.8.4",
+    "truffle": "^5.1.55",
+    "truffle-plugin-verify": "^0.5.8",
     "web3": "^1.3.0"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "3.4.1-solc-0.7-2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-bn": "^0.2.1",
@@ -44,9 +48,7 @@
     "prettier-plugin-solidity": "^1.0.0-beta.1",
     "solhint": "^3.3.2",
     "solhint-plugin-prettier": "0.0.5",
-    "solidity-coverage": "^0.7.12",
-    "truffle": "^5.1.55",
-    "truffle-plugin-verify": "^0.5.8"
+    "solidity-coverage": "^0.7.12"
   },
   "engines": {
     "node": ">= 14"


### PR DESCRIPTION
Since the new approach is to verify contracts by using standard-json on Etherscan and Sourcify on Blockscout, the previous content of the docker image does not allow to use it. So, the current PR refactor Dockerfile to solve the issue.

Also the docker images starts including remixd as so the container could be used provider of contract sources for the Remix IDE.