### PR TITLE
Lazy setting of bridged tokens metadata

### DIFF
--- a/contracts/mocks/NFTWithoutMetadata.sol
+++ b/contracts/mocks/NFTWithoutMetadata.sol
@@ -1,0 +1,35 @@
+pragma solidity 0.7.5;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "../interfaces/IERC1155TokenReceiver.sol";
+
+contract NFTWithoutMetadata {
+    function safeTransferFrom(
+        address _from,
+        address _to,
+        uint256 _id,
+        bytes memory _data
+    ) external {
+        IERC721Receiver to = IERC721Receiver(_to);
+        require(to.onERC721Received(msg.sender, _from, _id, _data) == to.onERC721Received.selector);
+    }
+
+    function safeTransferFrom(
+        address _from,
+        address _to,
+        uint256 _id,
+        uint256 _amount,
+        bytes memory _data
+    ) external {
+        IERC1155TokenReceiver to = IERC1155TokenReceiver(_to);
+        require(to.onERC1155Received(msg.sender, _from, _id, _amount, _data) == to.onERC1155Received.selector);
+    }
+
+    function balanceOf(address, uint256) external view returns (uint256) {
+        return 1000;
+    }
+
+    function ownerOf(uint256) external view returns (address) {
+        return msg.sender;
+    }
+}

--- a/contracts/tokens/ERC1155BridgeToken.sol
+++ b/contracts/tokens/ERC1155BridgeToken.sol
@@ -113,6 +113,18 @@ contract ERC1155BridgeToken is ERC1155, IBurnableMintableERC1155Token {
     }
 
     /**
+     * @dev Updated bridged token name/symbol parameters.
+     * Only bridge owner or bridge itself can call this method.
+     * @param _name new name parameter, will be saved as is, without additional suffixes like " from Mainnet".
+     * @param _symbol new symbol parameter.
+     */
+    function setMetadata(string calldata _name, string calldata _symbol) external onlyOwner {
+        require(bytes(_name).length > 0 && bytes(_symbol).length > 0);
+        name = _name;
+        symbol = _symbol;
+    }
+
+    /**
      * @dev Updates the bridge contract address.
      * Can be called by bridge owner after token contract was instantiated.
      * @param _bridgeContract address of the new bridge contract.
@@ -170,6 +182,6 @@ contract ERC1155BridgeToken is ERC1155, IBurnableMintableERC1155Token {
             uint64 patch
         )
     {
-        return (1, 1, 0);
+        return (1, 2, 0);
     }
 }

--- a/contracts/tokens/ERC721BridgeToken.sol
+++ b/contracts/tokens/ERC721BridgeToken.sol
@@ -77,6 +77,29 @@ contract ERC721BridgeToken is ERC721, IBurnableMintableERC721Token {
         _burn(_tokenId);
     }
 
+    // hack to access private fields in ERC721 contract
+    struct MetadataStorage {
+        string name;
+        string symbol;
+    }
+
+    /**
+     * @dev Updated bridged token name/symbol parameters.
+     * Only bridge owner or bridge itself can call this method.
+     * @param _name new name parameter, will be saved as is, without additional suffixes like " from Mainnet".
+     * @param _symbol new symbol parameter.
+     */
+    function setMetadata(string calldata _name, string calldata _symbol) external onlyOwner {
+        require(bytes(_name).length > 0 && bytes(_symbol).length > 0);
+
+        MetadataStorage storage metadata;
+        assembly {
+            metadata.slot := 6
+        }
+        metadata.name = _name;
+        metadata.symbol = _symbol;
+    }
+
     /**
      * @dev Sets the base URI for all tokens.
      * Can be called by bridge owner after token contract was instantiated.
@@ -118,6 +141,6 @@ contract ERC721BridgeToken is ERC721, IBurnableMintableERC721Token {
             uint64 patch
         )
     {
-        return (1, 0, 1);
+        return (1, 1, 0);
     }
 }

--- a/contracts/upgradeable_contracts/omnibridge_nft/BasicNFTOmnibridge.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/BasicNFTOmnibridge.sol
@@ -86,8 +86,10 @@ abstract contract BasicNFTOmnibridge is
     ) external onlyMediator {
         address bridgedToken = bridgedTokenAddress(_token);
         if (bridgedToken == address(0)) {
-            if (bytes(_name).length == 0) {
-                require(bytes(_symbol).length > 0);
+            if (bytes(_name).length == 0 && bytes(_symbol).length == 0) {
+                _name = "Bridged NFT";
+                _symbol = "NFT";
+            } else if (bytes(_name).length == 0) {
                 _name = _symbol;
             } else if (bytes(_symbol).length == 0) {
                 _symbol = _name;
@@ -295,8 +297,6 @@ abstract contract BasicNFTOmnibridge is
 
             string memory name = _readName(_token);
             string memory symbol = _readSymbol(_token);
-
-            require(bytes(name).length > 0 || bytes(symbol).length > 0);
 
             return
                 abi.encodeWithSelector(

--- a/contracts/upgradeable_contracts/omnibridge_nft/BasicNFTOmnibridge.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/BasicNFTOmnibridge.sol
@@ -86,17 +86,19 @@ abstract contract BasicNFTOmnibridge is
     ) external onlyMediator {
         address bridgedToken = bridgedTokenAddress(_token);
         if (bridgedToken == address(0)) {
-            if (bytes(_name).length == 0 && bytes(_symbol).length == 0) {
-                _name = "Bridged NFT";
-                _symbol = "NFT";
-            } else if (bytes(_name).length == 0) {
-                _name = _symbol;
-            } else if (bytes(_symbol).length == 0) {
-                _symbol = _name;
+            if (bytes(_name).length == 0) {
+                if (bytes(_symbol).length > 0) {
+                    _name = _transformName(_symbol);
+                }
+            } else {
+                if (bytes(_symbol).length == 0) {
+                    _symbol = _name;
+                }
+                _name = _transformName(_name);
             }
             bridgedToken = _values.length > 0
-                ? address(new ERC1155TokenProxy(tokenImageERC1155(), _transformName(_name), _symbol, address(this)))
-                : address(new ERC721TokenProxy(tokenImageERC721(), _transformName(_name), _symbol, address(this)));
+                ? address(new ERC1155TokenProxy(tokenImageERC1155(), _name, _symbol, address(this)))
+                : address(new ERC721TokenProxy(tokenImageERC721(), _name, _symbol, address(this)));
             _setTokenAddressPair(_token, bridgedToken);
         }
 

--- a/test/omnibridge_nft/common.test.js
+++ b/test/omnibridge_nft/common.test.js
@@ -1135,6 +1135,22 @@ function runTests(accounts, isHome) {
             expect(await deployedToken.symbol()).to.be.equal('Test')
           })
 
+          it('should use default name, which can be reset later', async () => {
+            const data = deployAndHandleBridgedERC721({ tokenId: 1, name: '', symbol: '' })
+
+            expect(await executeMessageCall(exampleMessageId, data)).to.be.equal(true)
+
+            const deployedToken = await ERC721BridgeToken.at(await contract.bridgedTokenAddress(otherSideToken1))
+            expect(await deployedToken.name()).to.be.equal(modifyName('Bridged NFT'))
+            expect(await deployedToken.symbol()).to.be.equal('NFT')
+
+            await deployedToken.setMetadata('newName', 'newSymbol', { from: user }).should.be.rejected
+            await deployedToken.setMetadata('newName', 'newSymbol', { from: owner }).should.be.fulfilled
+
+            expect(await deployedToken.name()).to.be.equal('newName')
+            expect(await deployedToken.symbol()).to.be.equal('newSymbol')
+          })
+
           it('should not allow to operate when execution is disabled globally', async () => {
             const data = deployAndHandleBridgedERC721({ tokenId: 1 })
 
@@ -1691,6 +1707,22 @@ function runTests(accounts, isHome) {
             expect(events.length).to.be.equal(1)
             const event = await getEvents(contract, { event: 'TokensBridged' })
             expect(event.length).to.be.equal(2)
+          })
+
+          it('should use default name, which can be reset later', async () => {
+            const data = deployAndHandleBridgedERC1155({ tokenIds: [1, 2], values: [1, 3], name: '', symbol: '' })
+
+            expect(await executeMessageCall(exampleMessageId, data)).to.be.equal(true)
+
+            const deployedToken = await ERC1155BridgeToken.at(await contract.bridgedTokenAddress(otherSideToken1))
+            expect(await deployedToken.name()).to.be.equal(modifyName('Bridged NFT'))
+            expect(await deployedToken.symbol()).to.be.equal('NFT')
+
+            await deployedToken.setMetadata('newName', 'newSymbol', { from: user }).should.be.rejected
+            await deployedToken.setMetadata('newName', 'newSymbol', { from: owner }).should.be.fulfilled
+
+            expect(await deployedToken.name()).to.be.equal('newName')
+            expect(await deployedToken.symbol()).to.be.equal('newSymbol')
           })
         })
 

--- a/test/omnibridge_nft/common.test.js
+++ b/test/omnibridge_nft/common.test.js
@@ -1159,8 +1159,8 @@ function runTests(accounts, isHome) {
             expect(await executeMessageCall(exampleMessageId, data)).to.be.equal(true)
 
             const deployedToken = await ERC721BridgeToken.at(await contract.bridgedTokenAddress(otherSideToken1))
-            expect(await deployedToken.name()).to.be.equal(modifyName('Bridged NFT'))
-            expect(await deployedToken.symbol()).to.be.equal('NFT')
+            expect(await deployedToken.name()).to.be.equal('')
+            expect(await deployedToken.symbol()).to.be.equal('')
 
             await deployedToken.setMetadata('newName', 'newSymbol', { from: user }).should.be.rejected
             await deployedToken.setMetadata('newName', 'newSymbol', { from: owner }).should.be.fulfilled
@@ -1750,8 +1750,8 @@ function runTests(accounts, isHome) {
             expect(await executeMessageCall(exampleMessageId, data)).to.be.equal(true)
 
             const deployedToken = await ERC1155BridgeToken.at(await contract.bridgedTokenAddress(otherSideToken1))
-            expect(await deployedToken.name()).to.be.equal(modifyName('Bridged NFT'))
-            expect(await deployedToken.symbol()).to.be.equal('NFT')
+            expect(await deployedToken.name()).to.be.equal('')
+            expect(await deployedToken.symbol()).to.be.equal('')
 
             await deployedToken.setMetadata('newName', 'newSymbol', { from: user }).should.be.rejected
             await deployedToken.setMetadata('newName', 'newSymbol', { from: owner }).should.be.fulfilled


### PR DESCRIPTION
Allow bridge owner to set missing tokens metadata after its deployment.