### PR TITLE
Bump package and contracts interfaces version prior to 2.0.0-rc5

### DIFF
--- a/contracts/upgradeable_contracts/omnibridge_nft/components/common/NFTOmnibridgeInfo.sol
+++ b/contracts/upgradeable_contracts/omnibridge_nft/components/common/NFTOmnibridgeInfo.sol
@@ -38,7 +38,7 @@ contract NFTOmnibridgeInfo is VersionableBridge {
             uint64 patch
         )
     {
-        return (3, 0, 0);
+        return (3, 1, 0);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnibridge-nft",
-  "version": "2.0.0-rc4",
+  "version": "2.0.0-rc5",
   "description": "Omnibridge NFT AMB extension",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The version has been updated since there were changes in the logic of the mediator contract made under #43.